### PR TITLE
Fix Strapi integration for blog posts

### DIFF
--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -121,11 +121,11 @@ const BlogPage = () => {
                 </div>
                 <div className="lg:p-8">
                   <img
-                    src={featuredPost.attributes.featuredImage?.data ? 
-                      getStrapiImageUrl(featuredPost.attributes.featuredImage.data.attributes.url) : 
+                    src={featuredPost.attributes.cover ?
+                      getStrapiImageUrl(featuredPost.attributes.cover.url) :
                       "https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=600&h=300&fit=crop"
                     }
-                    alt={featuredPost.attributes.featuredImage?.data?.attributes.alternativeText || featuredPost.attributes.title}
+                    alt={featuredPost.attributes.cover?.alternativeText || featuredPost.attributes.title}
                     className="w-full h-64 lg:h-80 object-cover rounded-lg"
                   />
                 </div>
@@ -144,11 +144,11 @@ const BlogPage = () => {
               {filteredPosts.map((post, index) => (
                 <article key={post.id} className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow">
                   <img
-                    src={post.attributes.featuredImage?.data ? 
-                      getStrapiImageUrl(post.attributes.featuredImage.data.attributes.url) : 
+                    src={post.attributes.cover ?
+                      getStrapiImageUrl(post.attributes.cover.url) :
                       "https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=600&h=300&fit=crop"
                     }
-                    alt={post.attributes.featuredImage?.data?.attributes.alternativeText || `Featured image for blog post: ${post.attributes.title}`}
+                    alt={post.attributes.cover?.alternativeText || `Featured image for blog post: ${post.attributes.title}`}
                     className="w-full h-48 object-cover"
                   />
                   <div className="p-6">

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -78,8 +78,8 @@ const BlogPostPage = () => {
     "@type": "Article",
     "headline": post.attributes.title,
     "description": post.attributes.excerpt,
-    "image": post.attributes.featuredImage?.data ? 
-      getStrapiImageUrl(post.attributes.featuredImage.data.attributes.url) : 
+    "image": post.attributes.cover ?
+      getStrapiImageUrl(post.attributes.cover.url) :
       "https://whiz.so/og-image.jpg",
     "author": {
       "@type": "Person",
@@ -114,8 +114,8 @@ const BlogPostPage = () => {
         ogType="article"
         ogImage={post.attributes.seo?.metaImage?.data ? 
           getStrapiImageUrl(post.attributes.seo.metaImage.data.attributes.url) : 
-          (post.attributes.featuredImage?.data ? 
-            getStrapiImageUrl(post.attributes.featuredImage.data.attributes.url) : 
+          (post.attributes.cover ?
+            getStrapiImageUrl(post.attributes.cover.url) :
             undefined
           )
         }
@@ -161,11 +161,11 @@ const BlogPostPage = () => {
             </div>
 
             <img
-              src={post.attributes.featuredImage?.data ? 
-                getStrapiImageUrl(post.attributes.featuredImage.data.attributes.url) : 
+              src={post.attributes.cover ?
+                getStrapiImageUrl(post.attributes.cover.url) :
                 "https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=1200&h=600&fit=crop"
               }
-              alt={post.attributes.featuredImage?.data?.attributes.alternativeText || `Featured image for: ${post.attributes.title}`}
+              alt={post.attributes.cover?.alternativeText || `Featured image for: ${post.attributes.title}`}
               className="w-full h-64 md:h-96 object-cover rounded-xl mb-8"
             />
           </header>

--- a/src/services/strapi.ts
+++ b/src/services/strapi.ts
@@ -17,13 +17,12 @@ export interface BlogPost {
     publishedAt: string;
     category: string;
     readTime: string;
-    featuredImage?: {
-      data?: {
-        attributes: {
-          url: string;
-          alternativeText?: string;
-        };
-      };
+    cover?: {
+      url: string;
+      alternativeText?: string;
+      width?: number;
+      height?: number;
+      formats?: any; // Or a more specific type for formats
     };
     seo?: {
       metaTitle?: string;
@@ -283,7 +282,7 @@ export const getFeaturedPosts = async (limit = 3): Promise<BlogPost[]> => {
     console.log('Fetching featured posts from Strapi');
     
     const response = await fetch(
-      `${config.strapi.apiUrl}/articles?populate=*&filters[featured][$eq]=true&pagination[limit]=${limit}&sort=publishedAt:desc`,
+      `${config.strapi.apiUrl}/articles?populate=*&sort=publishedAt:desc&pagination[limit]=${limit}`,
       {
         method: 'GET',
         headers: {


### PR DESCRIPTION
- Update API call for featured posts to fetch the latest posts instead of filtering by a non-existent 'featured' field.
- Update BlogPost interface and components to use 'cover.url' for images instead of 'featuredImage.data.attributes.url', aligning with the Strapi API response.