### PR TITLE
Add robust guards to BlogPage rendering

### DIFF
--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -92,7 +92,7 @@ const BlogPage = () => {
           </div>
 
           {/* Featured Post */}
-          {featuredPost && (
+          {featuredPost && featuredPost.attributes && (
             <div className="bg-gradient-to-r from-blue-600 to-purple-600 rounded-xl overflow-hidden mb-16">
               <div className="grid lg:grid-cols-2 gap-8 items-center">
                 <div className="p-8 text-white">
@@ -111,7 +111,7 @@ const BlogPage = () => {
                     <Clock className="h-4 w-4 mr-2" />
                     <span>{featuredPost.attributes.readTime}</span>
                   </div>
-                  <Link 
+                  <Link
                     to={`/blog/${featuredPost.attributes.slug}`}
                     className="bg-white text-blue-600 px-6 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors inline-flex items-center"
                   >
@@ -125,7 +125,7 @@ const BlogPage = () => {
                       getStrapiImageUrl(featuredPost.attributes.cover.url) :
                       "https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=600&h=300&fit=crop"
                     }
-                    alt={featuredPost.attributes.cover?.alternativeText || featuredPost.attributes.title}
+                    alt={featuredPost.attributes.cover?.alternativeText || featuredPost.attributes.title || 'Featured post image'}
                     className="w-full h-64 lg:h-80 object-cover rounded-lg"
                   />
                 </div>
@@ -141,55 +141,58 @@ const BlogPage = () => {
             </div>
           ) : (
             <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-              {filteredPosts.map((post, index) => (
-                <article key={post.id} className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow">
-                  <img
-                    src={post.attributes.cover ?
-                      getStrapiImageUrl(post.attributes.cover.url) :
-                      "https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=600&h=300&fit=crop"
-                    }
-                    alt={post.attributes.cover?.alternativeText || `Featured image for blog post: ${post.attributes.title}`}
-                    className="w-full h-48 object-cover"
-                  />
-                  <div className="p-6">
-                    <div className="flex items-center justify-between mb-3">
-                      <span className="bg-blue-100 text-blue-800 px-3 py-1 rounded-full text-sm font-semibold">
-                        {post.attributes.category}
-                      </span>
-                      <div className="flex items-center text-sm text-gray-500">
-                        <Clock className="h-4 w-4 mr-1" />
-                        {post.attributes.readTime}
+              {filteredPosts && filteredPosts.length > 0 && filteredPosts.map((post, index) => (
+                // Ensure post and post.attributes exist before trying to access nested properties
+                post && post.attributes ? (
+                  <article key={post.id} className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow">
+                    <img
+                      src={post.attributes.cover ?
+                        getStrapiImageUrl(post.attributes.cover.url) :
+                        "https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=600&h=300&fit=crop"
+                      }
+                      alt={post.attributes.cover?.alternativeText || post.attributes.title || 'Blog post image'}
+                      className="w-full h-48 object-cover"
+                    />
+                    <div className="p-6">
+                      <div className="flex items-center justify-between mb-3">
+                        <span className="bg-blue-100 text-blue-800 px-3 py-1 rounded-full text-sm font-semibold">
+                          {post.attributes.category}
+                        </span>
+                        <div className="flex items-center text-sm text-gray-500">
+                          <Clock className="h-4 w-4 mr-1" />
+                          {post.attributes.readTime}
+                        </div>
+                      </div>
+
+                      <h3 className="text-xl font-bold text-gray-900 mb-3 line-clamp-2">
+                        {post.attributes.title}
+                      </h3>
+
+                      <p className="text-gray-600 mb-4 line-clamp-3">
+                        {post.attributes.excerpt}
+                      </p>
+
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center text-sm text-gray-500">
+                          <Calendar className="h-4 w-4 mr-1" />
+                          {new Date(post.attributes.publishedAt).toLocaleDateString()}
+                        </div>
+                        <Link
+                          to={`/blog/${post.attributes.slug}`}
+                          className="text-blue-600 hover:text-blue-700 font-semibold flex items-center"
+                        >
+                          Read More
+                          <ArrowRight className="h-4 w-4 ml-1" />
+                        </Link>
                       </div>
                     </div>
-                    
-                    <h3 className="text-xl font-bold text-gray-900 mb-3 line-clamp-2">
-                      {post.attributes.title}
-                    </h3>
-                    
-                    <p className="text-gray-600 mb-4 line-clamp-3">
-                      {post.attributes.excerpt}
-                    </p>
-                    
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center text-sm text-gray-500">
-                        <Calendar className="h-4 w-4 mr-1" />
-                        {new Date(post.attributes.publishedAt).toLocaleDateString()}
-                      </div>
-                      <Link 
-                        to={`/blog/${post.attributes.slug}`}
-                        className="text-blue-600 hover:text-blue-700 font-semibold flex items-center"
-                      >
-                        Read More
-                        <ArrowRight className="h-4 w-4 ml-1" />
-                      </Link>
-                    </div>
-                  </div>
-                </article>
+                  </article>
+                ) : null // Or some fallback UI for a malformed post object
               ))}
             </div>
           )}
 
-          {!loading && filteredPosts.length === 0 && (
+          {!loading && (!filteredPosts || filteredPosts.length === 0) && (
             <div className="text-center py-12">
               <p className="text-gray-600">No blog posts found for this category.</p>
             </div>


### PR DESCRIPTION
- Add checks for `post.attributes` and `featuredPost.attributes` before accessing them during rendering.
- This prevents TypeErrors if post objects are temporarily undefined or not fully populated during initial render cycles after data fetching.